### PR TITLE
OL3 Fixes / TMS and Reordering

### DIFF
--- a/src/common/layers/LayersDirective.js
+++ b/src/common/layers/LayersDirective.js
@@ -45,7 +45,7 @@
 
             scope.reorderLayer = function(startIndex, endIndex) {
               var length = mapService.map.getLayers().getArray().length - 1;
-              var layer = mapService.map.removeLayer(mapService.map.getLayers().getAt(length - startIndex));
+              var layer = mapService.map.removeLayer(mapService.map.getLayers().item(length - startIndex));
               mapService.map.getLayers().insertAt(length - endIndex, layer);
             };
 

--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -706,9 +706,9 @@
                 if (coordinate == null) {
                   return '';
                 }
-                var z = coordinate.z;
-                var x = coordinate.x;
-                var y = (1 << z) - coordinate.y - 1;
+                var z = coordinate[0];
+                var x = coordinate[1];
+                var y = (1 << z) - coordinate[2] - 1;
                 return '/proxy/?url=' + url + minimalConfig.name + '/' + z + '/' + x + '/' + y + '.png';
               }
             })


### PR DESCRIPTION
TMS servers are broken in ROGUE GeoNode Build with update to latest OL3 since coordinate is now an array.  Sync with https://github.com/openlayers/ol3/commit/ba035abb1fd68546506c91198f09b672319f70f8.  This PR should fix the issue.

Also, sync's with changes in https://github.com/openlayers/ol3/commit/4525276c6e5894080dc8554bc1621c7b6fcc22e2.  Reordering layers doesn't work currently.