### PR TITLE
Added ability to customize the OSM url

### DIFF
--- a/src/common/map/MapService.js
+++ b/src/common/map/MapService.js
@@ -550,6 +550,17 @@
         });
       } else {
         if (server.ptype === 'gxp_osmsource') {
+          var osmLocal = {
+            attributions: [
+              new ol.Attribution({
+                html: settings.OsmLocalAttribution
+              }),
+              ol.source.OSM.ATTRIBUTION
+            ],
+            crossOrigin: null,
+            url: settings.OsmLocalUrl
+          };
+          var osmSource = (settings.OsmLocalUrl !== 'default') ? osmLocal : '';
           layer = new ol.layer.Tile({
             metadata: {
               serverId: server.id,
@@ -557,7 +568,7 @@
               title: fullConfig.Title
             },
             visible: minimalConfig.visibility,
-            source: new ol.source.OSM()
+            source: new ol.source.OSM(osmSource)
           });
         } else if (server.ptype === 'gxp_bingsource') {
 

--- a/src/common/utils/Globals.js
+++ b/src/common/utils/Globals.js
@@ -9,7 +9,11 @@ var settings = {
   DDPrecision: 8,
   WFSVersion: '1.1.0',
   WMSVersion: '1.1.1',
-  WPSVersion: '1.0.0'
+  WPSVersion: '1.0.0',
+  //Set to OsmLocalUrl to 'default' for default mapnick osm basemap
+  OsmLocalUrl: 'default',
+  //OsmLocalUrl: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png',
+  OsmLocalAttribution: 'All maps &copy; <a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
 };
 
 var forEachArrayish = function(arrayish, funct) {


### PR DESCRIPTION
Feature addition #176 

Added two setting variables:

```javascript
var settings = {
  coordinateDisplay: coordinateDisplays.DMS,
  DDPrecision: 8,
  WFSVersion: '1.1.0',
  WMSVersion: '1.1.1',
  WPSVersion: '1.0.0',
  //Set to OsmLocalUrl to 'default' for default mapnick osm basemap
  OsmLocalUrl: 'default',
  //OsmLocalUrl: 'http://{a-c}.tile.opencyclemap.org/cycle/{z}/{x}/{y}.png',
  OsmLocalAttribution: 'All maps &copy; <a href="http://www.opencyclemap.org/">OpenCycleMap</a>'
};
```
OsmLocalAttribution is only used if OsmLocalUrl is not 'default'

Screenshot displays opencyclemap.org being used, instead of default mapnik.
<img width="640" alt="screen shot 2015-12-24 at 1 39 25 am" src="https://cloud.githubusercontent.com/assets/3616758/11992121/3e5b86b0-a9df-11e5-848b-8456b43f2893.png">

