### PR TITLE
Fix 'Undo' Bug

### DIFF
--- a/src/common/diff/FeatureDiffService.js
+++ b/src/common/diff/FeatureDiffService.js
@@ -346,7 +346,7 @@
       service_.merged.replaceLayers(layers);
 
       crs_ = goog.isDefAndNotNull(feature.crs) ? feature.crs : null;
-      var repoName = geogigService_.getRepoById(repoId_).name;
+      var repoName = geogigService_.getRepoById(repoId_).uuid;
       var splitFeature = feature.id.split('/');
       mapService_.map.getLayers().forEach(function(layer) {
         var metadata = layer.get('metadata');


### PR DESCRIPTION
Resolution to issue https://github.com/ROGUE-JCTD/MapLoom/issues/181.

The GeoGig repo ID is stored in the 'uuid' property, but MapLoom is referencing the 'name' property when attempting to undo changes, resulting in an error. This branch replaces 'name' with the correct property.