### PR TITLE
Fix zoom slider thumb offset

### DIFF
--- a/src/common/map/style/map.less
+++ b/src/common/map/style/map.less
@@ -23,7 +23,6 @@
   .ol-zoomslider-thumb {
     position: absolute;
     border-radius: 2px;
-    left: -2px !important;
     width: 24px;
     height: 12px;
   }


### PR DESCRIPTION
This is a resolution to https://github.com/ROGUE-JCTD/MapLoom/issues/192

The zoom slider thumb is offset from the slider by 2px, which is a style adjustment that is no longer necessary using OL v3.13.