### PR TITLE
Refactor Diff Service & Add Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
 node_js:
   - "0.10"
+  
+before_install:
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
 
 before_script:
   - export DISPLAY=:99.0

--- a/karma/karma-unit.tpl.js
+++ b/karma/karma-unit.tpl.js
@@ -17,14 +17,14 @@ module.exports = function ( karma ) {
       'src/assets/**/*.js'
     ],
     frameworks: [ 'jasmine' ],
-    plugins: [ 'karma-jasmine', 'karma-phantomjs-launcher' ],
+    plugins: [ 'karma-jasmine', 'karma-phantomjs-launcher', 'karma-spec-reporter' ],
     preprocessors: {
     },
 
     /**
      * How to report, by default.
      */
-    reporters: 'dots',
+    reporters: 'spec',
 
     /**
      * On which port should the browser connect, on which port is the test runner
@@ -57,4 +57,3 @@ module.exports = function ( karma ) {
     ]
   });
 };
-

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma": "^0.13.21",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
+    "karma-spec-reporter": "0.0.24",
     "phantomjs-prebuilt": "^2.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "karma": "^0.13.21",
     "karma-jasmine": "^0.3.7",
     "karma-phantomjs-launcher": "^1.0.0",
-    "karma-spec-reporter": "0.0.24",
-    "phantomjs-prebuilt": "^2.1.4"
+    "karma-spec-reporter": "~0.0.24",
+    "phantomjs-prebuilt": "^2.0.0"
   }
 }

--- a/src/common/diff/DiffService.js
+++ b/src/common/diff/DiffService.js
@@ -5,7 +5,10 @@
   var rootScope = null;
   var service_ = null;
   var difflayer_ = null;
+  var diffLayerFound;
+  var numOutside;
   var mapService_ = null;
+  var missingLayers = {};
   var geogigService_ = null;
   var featureDiffService_ = null;
   var dialogService_ = null;
@@ -36,6 +39,7 @@
       dialogService_ = dialogService;
       q_ = $q;
       service_ = this;
+
       var diffStyle = (function() {
         return function(feature, resolution) {
           var styles = {};
@@ -103,11 +107,116 @@
         }),
         style: diffStyle
       });
+
       rootScope.$on('translation_change', function() {
         difflayer_.get('metadata').title = translate_.instant('differences');
       });
       mapService_ = mapService;
       return this;
+    };
+
+    this.addChangeFeatureToCorrectChangeArray = function(change, feature) {
+      var splitFeature = change.id.split('/');
+
+      switch (change.change) {
+        case 'ADDED':
+          service_.adds.push(feature);
+          break;
+        case 'REMOVED':
+          service_.deletes.push(feature);
+          break;
+        case 'MODIFIED':
+          service_.modifies.push(feature);
+          break;
+        case 'CONFLICT':
+          if (diffLayerFound === false) {
+            service_.numOutside++;
+            missingLayers[splitFeature[0]] = true;
+          }
+          service_.conflicts.push(feature);
+          break;
+        case 'MERGED':
+          service_.merges.push(feature);
+          break;
+      }
+    };
+
+    this.activateMissingLayerWarningDialogue = function() {
+      var layerString = '';
+      var first = true;
+      for (var layer in missingLayers) {
+        if (first) {
+          first = false;
+        } else {
+          layerString += ', ';
+        }
+        layerString += layer;
+      }
+      dialogService_.warn(translate_.instant('warning'), translate_.instant('missing_layers_merge',
+          {count: numOutside}) + layerString, [translate_.instant('btn_ok')], false);
+    };
+
+    this.createOlFeatureBasedOnChange = function(change, repo) {
+      var crs = goog.isDefAndNotNull(change.crs) ? change.crs : null;
+      var geom;
+      var layers = mapService_.map.getLayers();
+      var olFeature = new ol.Feature();
+
+      diffLayerFound = false;
+      changeLayer = service_.findChangeLayer(change, repo, layers);
+
+      geom = WKT.read(change.geometry);
+
+      if (goog.isDefAndNotNull(changeLayer)) {
+        crs = changeLayer.metadata.projection;
+      }
+
+      if (goog.isDefAndNotNull(crs)) {
+        geom.transform(crs, mapService_.map.getView().getProjection());
+      }
+
+      olFeature.set('change', DiffColorMap[change.change]);
+      olFeature.setGeometry(geom);
+      change.olFeature = olFeature;
+
+      return olFeature;
+    };
+
+    this.createChangeFeatureMetadata = function(change, repo) {
+      var splitFeature = change.id.split('/');
+      var geom = WKT.read(change.geometry);
+
+      featureMeta = {
+        repo: repo,
+        layer: splitFeature[0],
+        feature: splitFeature[1],
+        extent: geom.getExtent()
+      };
+
+      return featureMeta;
+    };
+
+    /*
+      Given a change object, its GeoGig repository, and all map layers,
+      returns the layer to which the change object's feature belongs.
+    */
+
+    this.findChangeLayer = function(change, repo, layers) {
+      var splitFeature = change.id.split('/');
+      var changeLayer;
+
+      layers.forEach(function(layer) {
+        var metadata = layer.get('metadata');
+        if (goog.isDefAndNotNull(metadata)) {
+          if (goog.isDefAndNotNull(metadata.geogigStore) && metadata.geogigStore === repo) {
+            if (goog.isDefAndNotNull(metadata.nativeName) && metadata.nativeName === splitFeature[0]) {
+              changeLayer = layer;
+            }
+          }
+        }
+      });
+
+      return changeLayer;
     };
 
     this.resolveFeature = function(_feature) {
@@ -122,6 +231,7 @@
     };
 
     this.populate = function(_changeList, _repo, oldName, newName) {
+      missingLayers = {};
       service_.adds = [];
       service_.modifies = [];
       service_.deletes = [];
@@ -133,86 +243,29 @@
       difflayer_.getSource().clear();
       mapService_.map.removeLayer(difflayer_);
       mapService_.map.addLayer(difflayer_);
-      if (goog.isDefAndNotNull(_changeList)) {
-        var numOutside = 0;
-        var missingLayers = {};
-        forEachArrayish(_changeList, function(change) {
-          var crs = goog.isDefAndNotNull(change.crs) ? change.crs : null;
-          var layerFound = false;
-          var splitFeature = change.id.split('/');
-          mapService_.map.getLayers().forEach(function(layer) {
-            var metadata = layer.get('metadata');
-            if (goog.isDefAndNotNull(metadata)) {
-              if (goog.isDefAndNotNull(metadata.geogigStore) && metadata.geogigStore === _repo) {
-                if (goog.isDefAndNotNull(metadata.nativeName) && metadata.nativeName === splitFeature[0]) {
-                  layerFound = true;
-                  if (goog.isDefAndNotNull(metadata.projection)) {
-                    crs = metadata.projection;
-                  }
-                }
-              }
-            }
-          });
 
-          var geom = WKT.read(change.geometry);
-          if (goog.isDefAndNotNull(crs)) {
-            geom.transform(crs, mapService_.map.getView().getProjection());
-          }
-          var olFeature = new ol.Feature();
-          olFeature.set('change', DiffColorMap[change.change]);
-          olFeature.setGeometry(geom);
-          difflayer_.getSource().addFeature(olFeature);
-          change.olFeature = olFeature;
-          var feature = {
-            repo: _repo,
-            layer: splitFeature[0],
-            feature: splitFeature[1],
-            extent: geom.getExtent()
-          };
-          switch (change.change) {
-            case 'ADDED':
-              service_.adds.push(feature);
-              break;
-            case 'REMOVED':
-              service_.deletes.push(feature);
-              break;
-            case 'MODIFIED':
-              service_.modifies.push(feature);
-              break;
-            case 'CONFLICT':
-              if (layerFound === false) {
-                numOutside++;
-                missingLayers[splitFeature[0]] = true;
-              }
-              service_.conflicts.push(feature);
-              break;
-            case 'MERGED':
-              service_.merges.push(feature);
-              break;
-          }
+      if (goog.isDefAndNotNull(_changeList)) {
+        numOutside = 0;
+        forEachArrayish(_changeList, function(change) {
+          service_.updateAndSortChangeObject(change, _repo);
         });
 
         if (numOutside > 0) {
-          var layerString = '';
-          var first = true;
-          for (var layer in missingLayers) {
-            if (first) {
-              first = false;
-            } else {
-              layerString += ', ';
-            }
-            layerString += layer;
-          }
-          dialogService_.warn(translate_.instant('warning'), translate_.instant('missing_layers_merge',
-              {count: numOutside}) + layerString, [translate_.instant('btn_ok')], false);
+          service_.activateMissingLayerWarningDialogue();
         }
       }
+
       rootScope.$broadcast('diff_performed', _repo);
+
     };
 
     this.performDiff = function(repoId, options) {
       var deferredResponse = q_.defer();
-      geogigService_.command(repoId, 'diff', options).then(function(response) {
+
+      geogigService_.command(repoId, 'diff', options)
+      .then(_handleDiffResponse, _handleDiffResponseError);
+
+      function _handleDiffResponse(response) {
         service_.clearDiff();
         if (goog.isDefAndNotNull(response.Feature)) {
           service_.mergeDiff = false;
@@ -229,12 +282,26 @@
           }
         }
         deferredResponse.resolve(response);
-      }, function(reject) {
+      }
+
+      function _handleDiffResponseError(reject) {
         //failed to get diff
         console.log(reject);
         deferredResponse.reject();
-      });
+      }
+
       return deferredResponse.promise;
+    };
+
+    this.updateAndSortChangeObject = function(change, repo) {
+      var layers = mapService_.map.getLayers();
+      var changeLayer = service_.findChangeLayer(change, repo, layers);
+      var changeFeatureMetadata = service_.createChangeFeatureMetadata(change, repo);
+      var olChangeFeature = service_.createOlFeatureBasedOnChange(change, repo);
+      change.olFeature = olChangeFeature;
+      diffLayerFound = goog.isDefAndNotNull(changeLayer);
+      difflayer_.getSource().addFeature(olChangeFeature);
+      service_.addChangeFeatureToCorrectChangeArray(change, changeFeatureMetadata);
     };
 
     this.clearDiff = function() {

--- a/src/common/diff/DiffService.spec.js
+++ b/src/common/diff/DiffService.spec.js
@@ -1,0 +1,70 @@
+describe('DiffService', function(){
+  beforeEach(module('MapLoom'));
+  beforeEach(module('loom_diff_service'));
+
+  beforeEach(inject(function(_diffService_, _mapService_){
+    diffService = _diffService_;
+    mapService = _mapService_;
+    repoId = '9726b5d4-95de-43e3-ae9c-9ff59a43a737';
+
+    mockLayer = {
+      get: function(type){
+        if (type === 'metadata'){
+          return {
+            nativeName: 'incidentes_od3',
+            geogigStore: repoId
+          };
+        }
+      }
+    };
+
+    modifiedChange = { 
+      change: "MODIFIED",
+      crs: "EPSG:4326",
+      geometry: "POINT (-81.50724532541271 27.472059426243238)",
+      id: "incidentes_od3/fid--4277d16a_14e8c4d9628_-7ffd"
+    };
+
+  }));
+  
+  describe('addChangeFeatureToCorrectChangeArray', function(){
+    it('should push modified change to modified array', function(){
+      var expectedResult;  
+
+      diffService.addChangeFeatureToCorrectChangeArray(modifiedChange, 'mockLayer');
+      diffService.modifies.forEach(function(modifiedFeature) {
+        if (modifiedFeature === 'mockLayer'){
+          expectedResult = true;
+        }
+      });
+      expect(expectedResult).toBe(true);
+    });
+  });
+
+  describe('createOlFeatureBasedOnChange', function(){
+    it('should return a valid OpenLayers feature object', function(){
+      var diffLayer = new ol.layer.Vector({
+        source: new ol.source.Vector({
+          parser: null
+        })
+      });
+      var validationFeature;
+      var olChangeFeature = diffService.createOlFeatureBasedOnChange(modifiedChange, repoId);
+      diffLayer.getSource().addFeature(olChangeFeature);
+      diffLayer.getSource().forEachFeature(function(iterFeature){
+        if (iterFeature === olChangeFeature) {
+          validationFeature = iterFeature;
+        }
+      });
+      expect(olChangeFeature).toBe(validationFeature);
+    });
+  });
+
+  describe('findChangeLayer', function(){
+    it('should return the map layer to which the change object belongs', function(){
+      var testLayer = diffService.findChangeLayer(modifiedChange, repoId, [mockLayer]);
+      expect(testLayer).toBe(mockLayer);
+    });
+  });
+
+});

--- a/src/common/map/MapService.spec.js
+++ b/src/common/map/MapService.spec.js
@@ -52,6 +52,13 @@ describe('MapService', function() {
       expect(map.values_.view).toBeDefined();
     });
 
+    it('should have the same CRS as the config service', function() {
+      var actualProjection = map.getView().getProjection().code_; 
+      var expectedProjection = configService.configuration.map.projection;  
+
+      expect(expectedProjection).toBe(actualProjection);
+    });
+
     it('should return a valid ol.Map object', function() {
       expect(map).not.toBe(null);
       expect(map).toBeDefined();
@@ -236,4 +243,3 @@ describe('MapService', function() {
     });
   });
 });
-


### PR DESCRIPTION
This branch:

- Refactors the diff service to make it more testable
- Adds test coverage for the diff service
- Adds a test to the map service to ensure that the CRS of the map is the same as the config service
- Adds code to the Travis CI file to account for an error described in this issue: https://github.com/travis-ci/travis-ci/issues/3225
- Adds karma-spec-reporter to the Karma config to view test output when 'grunt karma' is run from the console